### PR TITLE
Add list of supported languages and set option to load only languages

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -12,6 +12,8 @@ i18n
             loadPath: '/locales/{{lng}}/{{ns}}.json'
         },
         fallbackLng: 'en', // используй английский, если язык не обнаружен
+        supportedLngs: ['ru', 'en'],
+        load: 'languageOnly',
         debug: true,
         interpolation: {
             escapeValue: false, // не требуется для react, так как он умеет избегать XSS


### PR DESCRIPTION
[Here](https://www.i18next.com/overview/configuration-options) is a doc for these options. I added list of supported languages. It should cut all unsupported ones and allow to use only supported ones. And set option `load` to load only main (`en`) part of language instead of full (`en-US`) one